### PR TITLE
Allow running serve out-of-cluster

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -135,6 +135,24 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/howeyc/gopass"
+  packages = ["."]
+  revision = "bf9dde6d0d2c004a008c27aaee91170c786f6db8"
+
+[[projects]]
+  name = "github.com/imdario/mergo"
+  packages = ["."]
+  revision = "3e95a51e0639b4cf372f2ccf74c86749d747fbdc"
+  version = "0.2.2"
+
+[[projects]]
+  name = "github.com/inconshreveable/log15"
+  packages = ["."]
+  revision = "b105bd37f74e5d9dc7b6ad7806715c7a2b83fd3f"
+  version = "v2.11"
+
+[[projects]]
+  branch = "master"
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
@@ -156,6 +174,18 @@
   name = "github.com/mailru/easyjson"
   packages = ["buffer","jlexer","jwriter"]
   revision = "2f5df55504ebc322e4d52d34df6a1f5b503bf26d"
+
+[[projects]]
+  name = "github.com/mattn/go-colorable"
+  packages = ["."]
+  revision = "941b50ebc6efddf4c41c8e4537a5f68a4e686b24"
+  version = "v0.0.8"
+
+[[projects]]
+  name = "github.com/mattn/go-isatty"
+  packages = ["."]
+  revision = "fc9e8d8ef48496124e79ae0df75490096eccf6fe"
+  version = "v0.0.2"
 
 [[projects]]
   name = "github.com/matttproud/golang_protobuf_extensions"
@@ -213,15 +243,33 @@
 
 [[projects]]
   branch = "master"
+  name = "golang.org/x/crypto"
+  packages = ["ssh/terminal"]
+  revision = "4bc1c249b153ce1da9f55437759cec51fe6acabb"
+
+[[projects]]
+  branch = "master"
   name = "golang.org/x/net"
   packages = ["http2","http2/hpack","idna","lex/httplex"]
   revision = "b3756b4b77d7b13260a0a2ec658753cf48922eac"
 
 [[projects]]
   branch = "master"
+  name = "golang.org/x/sys"
+  packages = ["unix"]
+  revision = "7a4fde3fda8ef580a89dbae8138c26041be14299"
+
+[[projects]]
+  branch = "master"
   name = "golang.org/x/text"
   packages = ["internal/gen","internal/triegen","internal/ucd","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable","width"]
   revision = "836efe42bb4aa16aaa17b9c155d8813d336ed720"
+
+[[projects]]
+  name = "gopkg.in/inconshreveable/log15.v2"
+  packages = ["stack","term"]
+  revision = "dc7890abeaadcb6a79a9a5ee30bc1897bbf97713"
+  version = "v2.10"
 
 [[projects]]
   name = "gopkg.in/inf.v0"
@@ -243,25 +291,19 @@
 
 [[projects]]
   branch = "master"
-  name = "k8s.io/api"
-  packages = ["core/v1"]
-  revision = "e532fdb5587debfd7aade56dabe9eb5df9544baf"
-
-[[projects]]
-  branch = "master"
   name = "k8s.io/apimachinery"
   packages = ["pkg/api/equality","pkg/api/errors","pkg/api/meta","pkg/api/resource","pkg/apimachinery","pkg/apimachinery/announced","pkg/apimachinery/registered","pkg/apis/meta/v1","pkg/apis/meta/v1/unstructured","pkg/apis/meta/v1alpha1","pkg/conversion","pkg/conversion/queryparams","pkg/conversion/unstructured","pkg/fields","pkg/labels","pkg/openapi","pkg/runtime","pkg/runtime/schema","pkg/runtime/serializer","pkg/runtime/serializer/json","pkg/runtime/serializer/protobuf","pkg/runtime/serializer/recognizer","pkg/runtime/serializer/streaming","pkg/runtime/serializer/versioning","pkg/selection","pkg/types","pkg/util/cache","pkg/util/clock","pkg/util/diff","pkg/util/errors","pkg/util/framer","pkg/util/intstr","pkg/util/json","pkg/util/net","pkg/util/rand","pkg/util/runtime","pkg/util/sets","pkg/util/validation","pkg/util/validation/field","pkg/util/wait","pkg/util/yaml","pkg/version","pkg/watch","third_party/forked/golang/reflect"]
   revision = "a13245d02534abe88286859b547d041816f9a3f4"
 
 [[projects]]
   name = "k8s.io/client-go"
-  packages = ["discovery","kubernetes","kubernetes/scheme","kubernetes/typed/admissionregistration/v1alpha1","kubernetes/typed/apps/v1beta1","kubernetes/typed/authentication/v1","kubernetes/typed/authentication/v1beta1","kubernetes/typed/authorization/v1","kubernetes/typed/authorization/v1beta1","kubernetes/typed/autoscaling/v1","kubernetes/typed/autoscaling/v2alpha1","kubernetes/typed/batch/v1","kubernetes/typed/batch/v2alpha1","kubernetes/typed/certificates/v1beta1","kubernetes/typed/core/v1","kubernetes/typed/extensions/v1beta1","kubernetes/typed/networking/v1","kubernetes/typed/policy/v1beta1","kubernetes/typed/rbac/v1alpha1","kubernetes/typed/rbac/v1beta1","kubernetes/typed/settings/v1alpha1","kubernetes/typed/storage/v1","kubernetes/typed/storage/v1beta1","pkg/api","pkg/api/v1","pkg/api/v1/ref","pkg/apis/admissionregistration","pkg/apis/admissionregistration/v1alpha1","pkg/apis/apps","pkg/apis/apps/v1beta1","pkg/apis/authentication","pkg/apis/authentication/v1","pkg/apis/authentication/v1beta1","pkg/apis/authorization","pkg/apis/authorization/v1","pkg/apis/authorization/v1beta1","pkg/apis/autoscaling","pkg/apis/autoscaling/v1","pkg/apis/autoscaling/v2alpha1","pkg/apis/batch","pkg/apis/batch/v1","pkg/apis/batch/v2alpha1","pkg/apis/certificates","pkg/apis/certificates/v1beta1","pkg/apis/extensions","pkg/apis/extensions/v1beta1","pkg/apis/networking","pkg/apis/networking/v1","pkg/apis/policy","pkg/apis/policy/v1beta1","pkg/apis/rbac","pkg/apis/rbac/v1alpha1","pkg/apis/rbac/v1beta1","pkg/apis/settings","pkg/apis/settings/v1alpha1","pkg/apis/storage","pkg/apis/storage/v1","pkg/apis/storage/v1beta1","pkg/util","pkg/util/parsers","pkg/version","rest","rest/watch","tools/cache","tools/clientcmd/api","tools/metrics","transport","util/cert","util/flowcontrol","util/integer"]
+  packages = ["discovery","kubernetes","kubernetes/scheme","kubernetes/typed/admissionregistration/v1alpha1","kubernetes/typed/apps/v1beta1","kubernetes/typed/authentication/v1","kubernetes/typed/authentication/v1beta1","kubernetes/typed/authorization/v1","kubernetes/typed/authorization/v1beta1","kubernetes/typed/autoscaling/v1","kubernetes/typed/autoscaling/v2alpha1","kubernetes/typed/batch/v1","kubernetes/typed/batch/v2alpha1","kubernetes/typed/certificates/v1beta1","kubernetes/typed/core/v1","kubernetes/typed/extensions/v1beta1","kubernetes/typed/networking/v1","kubernetes/typed/policy/v1beta1","kubernetes/typed/rbac/v1alpha1","kubernetes/typed/rbac/v1beta1","kubernetes/typed/settings/v1alpha1","kubernetes/typed/storage/v1","kubernetes/typed/storage/v1beta1","pkg/api","pkg/api/v1","pkg/api/v1/ref","pkg/apis/admissionregistration","pkg/apis/admissionregistration/v1alpha1","pkg/apis/apps","pkg/apis/apps/v1beta1","pkg/apis/authentication","pkg/apis/authentication/v1","pkg/apis/authentication/v1beta1","pkg/apis/authorization","pkg/apis/authorization/v1","pkg/apis/authorization/v1beta1","pkg/apis/autoscaling","pkg/apis/autoscaling/v1","pkg/apis/autoscaling/v2alpha1","pkg/apis/batch","pkg/apis/batch/v1","pkg/apis/batch/v2alpha1","pkg/apis/certificates","pkg/apis/certificates/v1beta1","pkg/apis/extensions","pkg/apis/extensions/v1beta1","pkg/apis/networking","pkg/apis/networking/v1","pkg/apis/policy","pkg/apis/policy/v1beta1","pkg/apis/rbac","pkg/apis/rbac/v1alpha1","pkg/apis/rbac/v1beta1","pkg/apis/settings","pkg/apis/settings/v1alpha1","pkg/apis/storage","pkg/apis/storage/v1","pkg/apis/storage/v1beta1","pkg/util","pkg/util/parsers","pkg/version","rest","rest/watch","tools/auth","tools/cache","tools/clientcmd","tools/clientcmd/api","tools/clientcmd/api/latest","tools/clientcmd/api/v1","tools/metrics","transport","util/cert","util/flowcontrol","util/homedir","util/integer"]
   revision = "df46f7f13b3da19b90b8b4f0d18b8adc6fbf28dc"
   version = "v4.0.0-beta.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "5c515bc53c9316ab390e8febc1b359d1d2c3fd397c3cc38fd18b4a36236ae611"
+  inputs-digest = "34d8ab7a8049e631527276ab85ee79f0741daff5d1e939065559b0eea8a85173"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -19,8 +19,3 @@
 # [[override]]
 #  name = "github.com/x/y"
 #  version = "2.4.0"
-
-
-[[constraint]]
-  branch = "master"
-  name = "github.com/spf13/cobra"

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ all: $(BIN)
 
 build: deps $(BIN)
 $(BIN): bpf/bindata.go
-	GOOS=$(GOOS) go build \
+	go build \
 	     -ldflags "-X github.com/kinvolk/cgnet/cmd.version=$(VERSION)" \
 	     -o $@ .
 
@@ -35,7 +35,7 @@ deploy-clean: clean
 	docker rmi $(CONTAINER):latest
 
 deps: build-deps
-	dep ensure
+	dep ensure -v
 
 build-deps:
 	go get -u github.com/golang/dep/...

--- a/cmd/top.go
+++ b/cmd/top.go
@@ -30,6 +30,7 @@ var topCmd = &cobra.Command{
 func cmdTop(cmd *cobra.Command, args []string) {
 	if len(args) < 1 {
 		cmd.Usage()
+		os.Exit(0)
 	}
 
 	if err := bpf.Setup(args[0]); err != nil {

--- a/kube/events.go
+++ b/kube/events.go
@@ -1,24 +1,59 @@
 package kube
 
 import (
-	"log"
-
-	"k8s.io/api/core/v1"
+	log "github.com/inconshreveable/log15"
+	"k8s.io/client-go/pkg/api/v1"
 )
 
 type Event int
 
 const (
 	NewPodEvent Event = iota
+	UpdatePodEvent
 	DeletePodEvent
 )
 
-func emitEvent(eChan chan Event, e Event) func(obj interface{}) {
+func onAdd(events chan Event) func(obj interface{}) {
+	funclog := log.New("func", "onAdd")
 	return func(obj interface{}) {
-		_, ok := obj.(*v1.Pod)
+		pod, ok := obj.(*v1.Pod)
 		if !ok {
-			log.Printf("unexpected object type: %#v\n", obj)
+			funclog.Error("unable to assert type")
+			return
 		}
-		eChan <- e
+		events <- NewPodEvent
+		funclog.Info(pod.ObjectMeta.SelfLink)
+	}
+}
+
+func onUpdate(events chan Event) func(oldObj, newObj interface{}) {
+	// funclog := log.New("func", "onUpdate")
+	return func(oldObj, newObj interface{}) {
+		// do nothing
+		return
+		// oldPod, ok := oldObj.(*v1.Pod)
+		// if !ok {
+		// 	funclog.Error("unable to assert type")
+		// 	return
+		// }
+		// newPod, ok := newObj.(*v1.Pod)
+		// if !ok {
+		// 	funclog.Error("unable to assert type")
+		// 	return
+		// }
+		// funclog.Info(fmt.Sprintf("old: %s, new: %s", oldPod.ObjectMeta.SelfLink, newPod.ObjectMeta.SelfLink))
+	}
+}
+
+func onDelete(events chan Event) func(obj interface{}) {
+	funclog := log.New("func", "onDelete")
+	return func(obj interface{}) {
+		pod, ok := obj.(*v1.Pod)
+		if !ok {
+			funclog.Error("unable to assert type")
+			return
+		}
+		events <- DeletePodEvent
+		funclog.Info(pod.ObjectMeta.SelfLink)
 	}
 }


### PR DESCRIPTION
- kubeconfig can be passed via flag
- nicer logging
- using `context` instead of `chan struct{}`

**Todo:**

Debug TypeAssertionError in `onAdd`, `onUpdate` and `onDelete` ✅  

```
t=2017-07-20T15:24:16+0000 lvl=eror msg="unable to assert type" func=onAdd want= got=
t=2017-07-20T15:24:16+0000 lvl=eror msg="unable to assert type" func=onAdd want= got=
t=2017-07-20T15:24:16+0000 lvl=eror msg="unable to assert type" func=onAdd want= got=
ERROR: logging before flag.Parse: E0720 15:24:17.215699   16917 reflector.go:363] github.com/kinvolk/cgnet/kube/pods.go:61: expected type *v1.Pod, but watch event object had type *v1.Pod
ERROR: logging before flag.Parse: E0720 15:24:18.222761   16917 reflector.go:363] github.com/kinvolk/cgnet/kube/pods.go:61: expected type *v1.Pod, but watch event object had type *v1.Pod
```

As suspected the problem was the wrong use of `k8s.io/api/v1` instead of `k8s.io/client-go/pkg/api/v1`

Closes #9 