### PR TITLE
Remove kernel source tree dependency

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -1,7 +1,6 @@
 OUTDIR=out
 OUTFILE=$(OUTDIR)/cgnet.o
 
-LINUX_HEADERS="/usr/lib/modules/$(shell uname -r)/build"
 
 .PHONY: all build clean
 
@@ -11,8 +10,8 @@ $(OUTFILE):
 	mkdir -p $(OUTDIR)
 	clang -D__KERNEL__ -D__ASM_SYSREG_H \
 	-Wno-unused-value -Wno-pointer-sign -Wno-compare-distinct-pointer-types \
+			-fno-stack-protector \
 			-O2 -emit-llvm -c "src/cgnet.c" \
-			$(foreach path,$(LINUX_HEADERS), -I $(path)/arch/x86/include -I $(path)/arch/x86/include/generated -I $(path)/include -I $(path)/include/generated/uapi -I $(path)/arch/x86/include/uapi -I $(path)/include/uapi) \
 			-o - | llc -march=bpf -filetype=obj -o $(OUTFILE)
 
 bindata.go:


### PR DESCRIPTION
cgnet shoudn't require kernel source to be available and using headers from /usr/include should be enough. We achieved that by adjusting includes and using underscored types and macros.